### PR TITLE
Not using a fake user-agent as the default one. Making user-agent configurable.

### DIFF
--- a/humble.py
+++ b/humble.py
@@ -1129,6 +1129,8 @@ to 'scheme_host_port_yyyymmdd.ext' file (csv/json files will contain a brief \
 analysis)")
 parser.add_argument("-op", dest='output_path', type=str, help="save analysis \
 to OUTPUT_PATH (if omitted, the PATH of 'humble.py' will be used)")
+parser.add_argument("-ua", dest='user_agent', type=str, help="if set, will \
+override the default User-Agent header")
 parser.add_argument("-r", dest='ret', action="store_true", help="show HTTP \
 response headers and a detailed analysis ('-b' parameter will take priority)")
 parser.add_argument('-u', type=str, dest='URL', help="scheme, host and port to\
@@ -1207,8 +1209,11 @@ exception_d = {
 }
 requests.packages.urllib3.disable_warnings()
 
-c_headers = {'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) \
-AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36'}
+c_headers = {
+    'User-Agent':
+        args.user_agent or
+        'humble'
+}
 
 headers, status_code, reliable, request_time = manage_http_request()
 


### PR DESCRIPTION
## Description
Thanks for an awesome tool! In my opinion a fake user/agent should not be the default one, therefore
I suggest changing the default user-agent to `humble`. Besides that, I have made the user-agent configurable.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Running a simple HTTP server and testing Humble both with ua argument set and unset, checking what is the User-Agent header.

## Checklist:

- [ ] My code follows the style guidelines of this project - used flake8, where are the guidelines?
- [X] I have performed a self-review of my own code
- [N/A] I have commented my code, particularly in hard-to-understand areas
- [N/A] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings - used flake8
- [ ] I have added tests that prove my fix is effective or that my feature works - where are the tests?
- [ ] New and existing unit tests pass locally with my changes - where are the tests?
- [N/A] Any dependent changes have been merged and published in downstream modules
- [X] I have checked my code and corrected any misspellings
