### PR TITLE
Fixed: SyntaxError: invalid syntax

### DIFF
--- a/humble.py
+++ b/humble.py
@@ -1315,10 +1315,10 @@ def format_html_enabled(ln, sub_d):
         ln = f" {ln[19:].rstrip()}"
         if ':' in ln:
             header, value = ln.split(":", 1)
-            ln = f"<span class='ok'> {header.strip()}{sub_d["span_f"]}:\
-{value.strip()}"
+            ln = f"<span class='ok'> {header.strip()}{sub_d['span_f']}:" \
+                 f"{value.strip()}"
         else:
-            ln = f"<span class='ok'> {ln.strip()}{sub_d["span_f"]}"
+            ln = f"<span class='ok'> {ln.strip()}{sub_d['span_f']}"
         html_final.write(f'{ln}{sub_d["span_f"]}<br>')
     return ln, ln_enabled
 


### PR DESCRIPTION
```
docker run -it --rm --name humble humble:1.42 /bin/bash -c "python3 humble.py -u https://facebook.com -b"
  File "humble.py", line 1318
    ln = f"<span class='ok'> {header.strip()}{sub_d["span_f"]}:\
                                                     ^
SyntaxError: invalid syntax
```

Fixed by changing "->'

<img width="1885" alt="image" src="https://github.com/user-attachments/assets/5d708f07-00eb-4b81-85b5-6026528dc46a">
