### PR TITLE
Fix: f-string backslash and unterminated string literal errors remedi…

### DIFF
--- a/humble.py
+++ b/humble.py
@@ -456,9 +456,9 @@ def print_analysis_results(totals, max_secl, en_cnt_w):
         print(f"{print_detail_s(literal, max_ln=True):<{max_secl}} {total}",
               end='')
         if idx == 0 and en_cnt_w:
-            print(f"{print_detail_s('[enabled_cnt_w]',
-                                    max_ln=True):<{max_secl}} \
-{get_detail('[enabled_cnt_wt]')}", end='')
+            val1 = print_detail_s('[enabled_cnt_w]', max_ln=True)
+            val2 = get_detail('[enabled_cnt_wt]')
+            print(f"{val1:<{max_secl}} {val2}", end='')
 
 
 def grade_analysis(en_cnt, m_cnt, f_cnt, i_cnt, e_cnt):
@@ -1071,7 +1071,7 @@ def check_unsafe_cookies():  # sourcery skip: use-named-expression
 
 def print_unsafe_cookies(unsafe_cks):
     print_detail_l('[icooks_s]' if len(unsafe_cks) > 1 else '[icook_s]')
-    print(f"{', '.join(f'\'{ck}\'' for ck in sorted(unsafe_cks))}.")
+    print(f"{', '.join(repr(ck) for ck in sorted(unsafe_cks))}.")
     print_detail('[iset]', num_lines=2)
 
 
@@ -2755,7 +2755,7 @@ if 'access-control-allow-methods' in headers_l and '5' not in skip_list:
         print_detail_r('[imethods_h]', is_red=True)
         if not args.brief:
             match_method = [x for x in t_methods if x in methods]
-            match_method_str = f"{', '.join(f"'{m}'" for m in match_method)}."
+            match_method_str = f"{', '.join(repr(m) for m in match_method)}."
             print_detail_l('[imethods_s]')
             print(match_method_str)
             print_detail('[imethods]')


### PR DESCRIPTION
## Description

* Switch to `repr(ck)` when joining during print to ensure proper escaping and literal representation.
* Use `repr(m)` when joining `match_method` entries to ensure proper escaping and literal representation.
* Extract `print_detail_s` and `get_detail` calls into `val1`/`val2` before formatting for single evaluation.

## Fixes # (issue)

Issue Encountered During Execution : 

SyntaxError: unterminated string literal (detected at line 459)
SyntaxError: f-string expression part cannot include a backslash

Images :

<img width="901" height="192" alt="image" src="https://github.com/user-attachments/assets/378bed46-687d-4e29-9754-f6872f987f0a" />

<img width="971" height="199" alt="image" src="https://github.com/user-attachments/assets/318ef2a0-23d0-4543-8c2c-5cac4ba8d0f0" />


## Type of change

- Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

- Tested the execution

## Checklist:

- My code follows the style guidelines of this project
- I have performed a self-review of my own code
- I have checked my code and corrected any misspellings
